### PR TITLE
Troubleshoot CI integration test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,24 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y zip
+          sudo apt-get install -y zip xvfb
+
+      - name: Install Chrome
+        run: |
+          wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+          sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
+          sudo apt-get update
+          sudo apt-get install -y google-chrome-stable
 
       - name: Lint
         run: yarn lint
 
       - name: Test
-        run: yarn test
+        run: |
+          export DISPLAY=:99
+          Xvfb :99 -screen 0 1024x768x24 &
+          sleep 3
+          yarn test
 
       - name: Build
         run: yarn build

--- a/jest.config.js
+++ b/jest.config.js
@@ -47,6 +47,7 @@ export default {
       extensionsToTreatAsEsm: ['.ts'],
       testMatch: ['**/integration/**/*.test.ts'],
       testEnvironment: 'node',
+      testTimeout: 120000, // 2 minutes timeout for integration tests
       transform: {
         '^.+\\.ts$': [
           'ts-jest',

--- a/test/integration/extension-loader.ts
+++ b/test/integration/extension-loader.ts
@@ -1,6 +1,7 @@
 import puppeteer, { Browser, Page } from 'puppeteer';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { existsSync } from 'fs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -13,32 +14,85 @@ interface ExtensionTestContext {
   extensionId: string;
 }
 
+// Check if we're running in CI
+const isCI = process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true';
+
 export async function loadExtensionInBrowser(): Promise<ExtensionTestContext> {
   const extensionPath = EXTENSION_PATH;
 
-  const browser = await puppeteer.launch({
-    headless: false, // Extensions require non-headless mode
-    pipe: true, // Recommended for better performance
-    enableExtensions: [extensionPath], // Modern way to load extensions
-    args: [
-      '--disable-blink-features=AutomationControlled',
-      '--no-first-run',
-      '--no-default-browser-check',
-      '--disable-dev-shm-usage',
-      '--disable-background-networking',
-      '--disable-sync',
-      '--disable-translate',
-      '--disable-web-security',
-      '--disable-features=VizDisplayCompositor',
-    ],
-  });
+  // Check if extension build directory exists
+  if (!existsSync(extensionPath)) {
+    throw new Error(`Extension build directory not found at: ${extensionPath}. Please run 'yarn build' first.`);
+  }
 
-  const page = await browser.newPage();
+  // Base Chrome arguments for extension testing
+  const chromeArgs = [
+    `--load-extension=${extensionPath}`,
+    `--disable-extensions-except=${extensionPath}`,
+    '--no-first-run',
+    '--no-default-browser-check',
+    '--disable-dev-shm-usage',
+    '--disable-background-networking',
+    '--disable-sync',
+    '--disable-translate',
+    '--disable-web-security',
+    '--disable-features=VizDisplayCompositor',
+    '--disable-blink-features=AutomationControlled',
+    '--disable-component-extensions-with-background-pages',
+    '--disable-background-timer-throttling',
+    '--disable-backgrounding-occluded-windows',
+    '--disable-renderer-backgrounding',
+    '--disable-field-trial-config',
+    '--disable-ipc-flooding-protection',
+  ];
 
-  // Get extension ID from chrome://extensions page
-  const extensionId = EXTENSION_ID;
+  // Add CI-specific arguments
+  if (isCI) {
+    chromeArgs.push(
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-gpu',
+      '--disable-software-rasterizer',
+      '--disable-accelerated-2d-canvas',
+      '--disable-accelerated-jpeg-decoding',
+      '--disable-accelerated-mjpeg-decode',
+      '--disable-accelerated-video-decode',
+      '--disable-accelerated-video-encode',
+      '--disable-background-media-suspend',
+      '--disable-extensions-file-access-check',
+      '--disable-hang-monitor',
+      '--disable-prompt-on-repost',
+      '--disable-domain-reliability',
+      '--disable-component-update',
+      '--disable-default-apps',
+      '--disable-plugins-discovery',
+      '--disable-plugins',
+      '--mute-audio',
+      '--single-process',
+      '--remote-debugging-port=9222'
+    );
+  }
 
-  return { browser, page, extensionId };
+  try {
+    const browser = await puppeteer.launch({
+      headless: isCI ? true : false, // Use headless mode for CI
+      args: chromeArgs,
+      timeout: 30000,
+      protocolTimeout: 30000,
+    });
+
+    const page = await browser.newPage();
+    await page.setDefaultTimeout(30000);
+    await page.setDefaultNavigationTimeout(30000);
+
+    // Get extension ID from chrome://extensions page
+    const extensionId = EXTENSION_ID;
+
+    return { browser, page, extensionId };
+  } catch (error) {
+    console.error('Failed to launch browser:', error);
+    throw error;
+  }
 }
 
 export async function openExtensionPopup(

--- a/test/integration/extension.test.ts
+++ b/test/integration/extension.test.ts
@@ -17,12 +17,25 @@ describe('Dyslexia Friendly Extension Integration Tests', () => {
   let context: ExtensionTestContext;
 
   beforeAll(async () => {
-    // Load the extension in browser
-    try {
-      context = await loadExtensionInBrowser();
-    } catch (error) {
-      console.error('Failed to load extension:', error);
-      throw error;
+    // Load the extension in browser with retry logic
+    let attempts = 0;
+    const maxAttempts = 3;
+    
+    while (attempts < maxAttempts) {
+      try {
+        context = await loadExtensionInBrowser();
+        break;
+      } catch (error) {
+        attempts++;
+        console.error(`Failed to load extension (attempt ${attempts}/${maxAttempts}):`, error);
+        
+        if (attempts === maxAttempts) {
+          throw error;
+        }
+        
+        // Wait before retrying
+        await new Promise(resolve => setTimeout(resolve, 2000));
+      }
     }
   });
 


### PR DESCRIPTION
Fix integration test failures in CI by updating Puppeteer configuration and CI environment setup.

The `TargetCloseError` indicated Puppeteer couldn't properly initialize Chrome for extension loading in the CI's headless environment. This PR configures Puppeteer with CI-specific arguments, installs Chrome, sets up a virtual display, and adds retry logic to ensure stable test execution.