### PR TITLE
fix(extension): keep reading ruler hidden in new tabs when disabled (RAN-23)

### DIFF
--- a/src/extension/css/contentscript.css
+++ b/src/extension/css/contentscript.css
@@ -237,6 +237,11 @@ body.dyslexia-friendly li:hover {
 /* Ruler */
 
 #dyslexia-friendly-ruler {
+  /* Hidden until config explicitly enables it (.show()). Without this the
+     div defaults to display:block and the always-on mousemove handler drags
+     it into view before/without a config arriving — making a disabled ruler
+     reappear on new tabs when config delivery is delayed (RAN-23). */
+  display: none;
   height: 1.6em;
   /* ideally keep in sync with default config */
   background-color: black;

--- a/src/extension/js/lib/__tests__/store.test.ts
+++ b/src/extension/js/lib/__tests__/store.test.ts
@@ -116,6 +116,31 @@ describe('store', () => {
     );
   });
 
+  // RAN-23: a new subscriber must be primed with the *stored* config,
+  // not DEFAULT_CONFIG. The old behaviour pushed rulerEnabled:true on every
+  // service-worker cold start, making a disabled ruler reappear in new tabs.
+  test('subscribe() primes the callback with stored config, not defaults', (done) => {
+    const storedConfig = { ...DEFAULT_CONFIG, rulerEnabled: false };
+    global.chrome = {
+      storage: {
+        sync: {
+          get: function (key, fn) {
+            fn({ config: { ...storedConfig } });
+          },
+        },
+      },
+    };
+    store.subscribe(function (config) {
+      try {
+        expect(config).toEqual(storedConfig);
+        expect(config.rulerEnabled).toBe(false);
+        done();
+      } catch (error) {
+        done(error);
+      }
+    });
+  });
+
   test('default config includes background options', () => {
     expect(DEFAULT_CONFIG.backgroundEnabled).toBe(false);
     expect(DEFAULT_CONFIG.backgroundChoice).toBe('none');

--- a/src/extension/js/lib/store.ts
+++ b/src/extension/js/lib/store.ts
@@ -144,6 +144,10 @@ export const store: Store = {
   // subscribe to changes in store
   subscribe: function (callback: ConfigCallback): void {
     subscribers.push(callback);
-    callback(DEFAULT_CONFIG);
+    // Prime with the actual stored config, not DEFAULT_CONFIG. Priming with
+    // defaults (rulerEnabled:true) pushed the ruler back on every
+    // service-worker cold start, making a disabled ruler reappear in new
+    // tabs (RAN-23).
+    store.getAll(callback);
   },
 };


### PR DESCRIPTION
Fixes the user-reported bug where a disabled reading ruler reappears in new tabs ([RAN-23](https://linear.app/randomcreations/issue/RAN-23/ruler-comes-back-in-new-tabs), GH #110).

## Before / after
New tab, ruler disabled by the user, after a service-worker cold start:

| Before (bug) | After (fix) |
|---|---|
| <img width="800" src="https://github.com/javoire/pr-assets/raw/main/screenshots/1780156116-754643.png" /> | <img width="800" src="https://github.com/javoire/pr-assets/raw/main/screenshots/1780156116-3215c1.png" /> |

The grey band on the left is the ruler reappearing despite being disabled; on the right it stays hidden.

## Two causes
1. `store.subscribe()` primed every subscriber with `DEFAULT_CONFIG` (`rulerEnabled:true`). The ephemeral MV3 service worker re-subscribes on each cold start, pushing ruler-ON and overriding stored settings. Now primes with the actual stored config via `store.getAll()`.
2. `#dyslexia-friendly-ruler` had no `display:none` default, so the div was `display:block` and the always-on `mousemove` handler dragged it into view before/without a config arriving. On a new tab where config delivery is delayed, the default-visible ruler showed. Defaulted it to `display:none` (jQuery `.show()` still reveals it when enabled).

The second cause was only caught by driving the **built** extension in real Chrome — the unit-test fix for cause #1 alone did not stop the symptom.

## Verification
- New unit test: `subscribe()` primes with stored config, not defaults.
- Puppeteer harness against the built extension: after a service-worker cold start with `rulerEnabled:false`, the ruler stays `display:none` on the new tab (screenshots above are captured from the buggy `main` build vs this branch's build).
- Regression check: ruler still shows when enabled (off→hidden, on→band at cursor, custom color/size correct).
- Full unit + integration suite (27 tests) and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)