### PR TITLE
feat(extension): show version number on about page (RAN-37)

### DIFF
--- a/src/extension/about.html
+++ b/src/extension/about.html
@@ -57,6 +57,7 @@
       </p>
     </div>
   </div>
+  <p id="version" class="version"></p>
 </div>
 </body>
 </html>

--- a/src/extension/css/popup.css
+++ b/src/extension/css/popup.css
@@ -166,3 +166,10 @@ a {
   display: block;
   margin-top: 9px;
 }
+
+#popup-wrapper .version {
+  margin-top: 12px;
+  text-align: center;
+  font-size: 12px;
+  opacity: 0.5;
+}

--- a/src/extension/js/about.ts
+++ b/src/extension/js/about.ts
@@ -1,0 +1,11 @@
+import '../../shared/css/tailwind.css';
+import '../../shared/css/fonts.css';
+
+import '../css/popup.css';
+
+// Single-source the version from the manifest at runtime
+const version = chrome.runtime.getManifest().version;
+const versionEl = document.getElementById('version');
+if (versionEl) {
+  versionEl.textContent = `Version ${version}`;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -108,6 +108,7 @@ const extensionConfig = {
   },
   entry: {
     popup: path.join(extensionSrcPath, 'js', 'popup.ts'),
+    about: path.join(extensionSrcPath, 'js', 'about.ts'),
     options: path.join(extensionSrcPath, 'js', 'options.ts'),
     serviceWorker: path.join(extensionSrcPath, 'js', 'serviceWorker.ts'),
     contentscript: path.join(extensionSrcPath, 'js', 'contentscript.ts'),
@@ -142,7 +143,7 @@ const extensionConfig = {
     new HtmlWebpackPlugin({
       template: path.join(extensionSrcPath, 'about.html'),
       filename: extensionOutPath + '/about.html',
-      chunks: ['popup'],
+      chunks: ['about'],
     }),
     new HtmlWebpackPlugin({
       template: path.join(extensionSrcPath, 'options.html'),


### PR DESCRIPTION
## Summary

The about page (reached via the circled-i link in the popup) now shows the extension version at the bottom, e.g. "Version 2.7.0".

The version is single-sourced from `manifest.json` at runtime via `chrome.runtime.getManifest().version` — never hardcoded.

## Changes

- `src/extension/about.html` — add a subtle `<p id="version" class="version">` footer placeholder.
- `src/extension/js/about.ts` — new entry script that sets the placeholder text from the manifest version (imports the same CSS as popup).
- `webpack.config.js` — add an `about` entry and point the about HtmlWebpackPlugin at the `about` chunk (matching the existing popup/options pattern).
- `src/extension/css/popup.css` — `.version` style (centered, small, 50% opacity).

## Verification

`yarn lint`, `yarn build`, and unit/integration tests all pass. Verified in headless Chrome with the built extension that the rendered text is "Version 2.7.0", matching `chrome.runtime.getManifest().version`.

<img width="800" src="https://github.com/javoire/pr-assets/raw/main/screenshots/1780161349-5f1463.png" />

Ticket: https://linear.app/randomcreations/issue/RAN-37

🤖 Generated with [Claude Code](https://claude.com/claude-code)