### PR TITLE
feat(extension): add custom background color option (RAN-19)

### DIFF
--- a/src/extension/js/contentscript.ts
+++ b/src/extension/js/contentscript.ts
@@ -45,9 +45,16 @@ $(document).ready(function () {
         body.addClass(FONT_CLASS_PREFIX + config.fontChoice);
       }
 
-      // remove previous background class
+      // remove previous background class and inline color
       removeClassStartsWith(body, BACKGROUND_CLASS_PREFIX);
-      if (config.backgroundEnabled && config.backgroundChoice !== 'none') {
+      body.css('background-color', '');
+      if (config.backgroundEnabled && config.backgroundChoice === 'custom') {
+        // custom color is applied inline instead of via a preset class
+        body.css('background-color', config.customBackgroundColor);
+      } else if (
+        config.backgroundEnabled &&
+        config.backgroundChoice !== 'none'
+      ) {
         body.addClass(BACKGROUND_CLASS_PREFIX + config.backgroundChoice);
       }
 
@@ -67,6 +74,7 @@ $(document).ready(function () {
       body.removeClass(CSS_NAMESPACE);
       removeClassStartsWith(body, FONT_CLASS_PREFIX);
       removeClassStartsWith(body, BACKGROUND_CLASS_PREFIX);
+      body.css('background-color', '');
       applyFontScale(root, false, config.fontSize);
       ruler.hide();
     }

--- a/src/extension/js/lib/__tests__/store.test.ts
+++ b/src/extension/js/lib/__tests__/store.test.ts
@@ -119,10 +119,22 @@ describe('store', () => {
   test('default config includes background options', () => {
     expect(DEFAULT_CONFIG.backgroundEnabled).toBe(false);
     expect(DEFAULT_CONFIG.backgroundChoice).toBe('none');
+    expect(DEFAULT_CONFIG.customBackgroundColor).toBe('#fdf6e3');
+  });
+
+  test('updates custom background color', () => {
+    const storedConfig = { ...DEFAULT_CONFIG };
+    const newConfigValues = {
+      backgroundChoice: 'custom',
+      customBackgroundColor: '#ffcc00',
+    };
+    const result = updateChangedConfigValues(storedConfig, newConfigValues);
+    expect(result.backgroundChoice).toBe('custom');
+    expect(result.customBackgroundColor).toBe('#ffcc00');
   });
 
   test('supports all background color options', () => {
-    const supportedBackgrounds = ['none', 'classic', 'cream', 'softblue', 'paleyellow'];
+    const supportedBackgrounds = ['none', 'classic', 'cream', 'softblue', 'paleyellow', 'custom'];
     
     // Test that updateChangedConfigValues works with all background options
     supportedBackgrounds.forEach(background => {

--- a/src/extension/js/lib/store.ts
+++ b/src/extension/js/lib/store.ts
@@ -12,6 +12,7 @@ export interface UserConfig {
   fontSize: number;
   backgroundEnabled: boolean;
   backgroundChoice: string;
+  customBackgroundColor: string;
 }
 
 export type ConfigKey = keyof UserConfig;
@@ -33,6 +34,7 @@ export const DEFAULT_CONFIG: UserConfig = {
   fontSize: 1.0,
   backgroundEnabled: false,
   backgroundChoice: 'none',
+  customBackgroundColor: '#fdf6e3',
 };
 
 export const updateChangedConfigValues = (

--- a/src/extension/js/popup.ts
+++ b/src/extension/js/popup.ts
@@ -99,7 +99,10 @@ function updateUiFromConfig(
 
   // toggle background
   removeClassStartsWith(body, BACKGROUND_CLASS_PREFIX);
-  if (config.backgroundEnabled && config.backgroundChoice !== 'none') {
+  body.css('background-color', '');
+  if (config.backgroundEnabled && config.backgroundChoice === 'custom') {
+    body.css('background-color', config.customBackgroundColor);
+  } else if (config.backgroundEnabled && config.backgroundChoice !== 'none') {
     body.addClass(BACKGROUND_CLASS_PREFIX + config.backgroundChoice);
   }
 

--- a/src/extension/js/popup.ts
+++ b/src/extension/js/popup.ts
@@ -106,6 +106,14 @@ function updateUiFromConfig(
     body.addClass(BACKGROUND_CLASS_PREFIX + config.backgroundChoice);
   }
 
+  // only show the custom color picker when the custom background is selected
+  const customColorWrapper = $('#background-custom-color-wrapper');
+  if (config.backgroundChoice === 'custom') {
+    customColorWrapper.show();
+  } else {
+    customColorWrapper.hide();
+  }
+
   // toggle visible sections
   const visibleSections = $('[data-show-when]');
   visibleSections.each(function (this: HTMLElement) {

--- a/src/extension/popup.html
+++ b/src/extension/popup.html
@@ -266,7 +266,7 @@
                 </label>
               </div>
 
-              <div class="relative">
+              <div class="relative" id="background-custom-color-wrapper">
                 <label for="background-custom-color" class="form-label"
                   >Color:</label
                 >

--- a/src/extension/popup.html
+++ b/src/extension/popup.html
@@ -249,6 +249,33 @@
                   Pale Yellow
                 </label>
               </div>
+
+              <div class="mb-[0.125rem] block min-h-[1.5rem] ps-[1.5rem]">
+                <input
+                  class="relative float-left -ms-[1.5rem] me-1 mt-0.5 h-5 w-5 appearance-none rounded-full border-2 border-solid border-secondary-500 before:pointer-events-none before:absolute before:h-4 before:w-4 before:scale-0 before:rounded-full before:bg-transparent before:opacity-0 before:shadow-checkbox before:shadow-transparent before:content-[''] after:absolute after:z-[1] after:block after:h-4 after:w-4 after:rounded-full after:content-[''] checked:border-primary checked:before:opacity-[0.16] checked:after:absolute checked:after:left-1/2 checked:after:top-1/2 checked:after:h-[0.625rem] checked:after:w-[0.625rem] checked:after:rounded-full checked:after:border-primary checked:after:bg-primary checked:after:content-[''] checked:after:[transform:translate(-50%,-50%)] hover:cursor-pointer hover:before:opacity-[0.04] hover:before:shadow-black/60 focus:shadow-none focus:outline-none focus:ring-0 focus:before:scale-100 focus:before:opacity-[0.12] focus:before:shadow-black/60 focus:before:transition-[box-shadow_0.2s,transform_0.2s] checked:focus:border-primary checked:focus:before:scale-100 checked:focus:before:shadow-checkbox checked:focus:before:transition-[box-shadow_0.2s,transform_0.2s] rtl:float-right dark:border-neutral-400 dark:checked:border-primary"
+                  type="radio"
+                  name="backgroundChoice"
+                  id="background-custom-radio"
+                  value="custom"
+                />
+                <label
+                  class="mt-px inline-block ps-[0.15rem] hover:cursor-pointer"
+                  for="background-custom-radio"
+                >
+                  Custom
+                </label>
+              </div>
+
+              <div class="relative">
+                <label for="background-custom-color" class="form-label"
+                  >Color:</label
+                >
+                <input
+                  type="color"
+                  name="customBackgroundColor"
+                  id="background-custom-color"
+                />
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
## What

Adds a **Custom** background color option to the Background section, alongside the existing presets (none, classic, cream, soft blue, pale yellow). When selected, the user-chosen color is applied as an inline `background-color` on the page body.

## Why

Completes RAN-19. The fixed presets don't cover every reader's preference; a custom picker lets users dial in any background shade.

## Changes

- `store.ts`: new `customBackgroundColor` field on `UserConfig` / `DEFAULT_CONFIG` (default `#fdf6e3`).
- `popup.html`: "Custom" radio (`value="custom"`) plus a `type="color"` input, mirroring the proven ruler color picker markup.
- `popup.ts`: live preview applies the custom color inline on the popup body; preset classes and inline style cleaned up when switching.
- `contentscript.ts`: when `backgroundEnabled && backgroundChoice === 'custom'`, applies the color as an inline style on `body`; removes preset classes and clears the inline style otherwise (and when the extension is disabled).
- `store.test.ts`: covers the new field default and custom-choice updates.

Scope is background color only (font color tracked separately in RAN-15).

## Verification

Puppeteer against the built extension on a local http page:
- custom `#ffcc00` → `getComputedStyle(body).backgroundColor === rgb(255, 204, 0)`
- cream preset still applies (`rgb(253, 246, 227)`), no leftover inline style
- switching custom → preset → none cleans up (inline style cleared, preset classes removed)

<img width="800" src="https://github.com/javoire/pr-assets/raw/main/screenshots/1780162016-88423a.png" />

https://linear.app/randomcreations/issue/RAN-19

🤖 Generated with [Claude Code](https://claude.com/claude-code)