### PR TITLE
feat(extension): add font color option (RAN-15)

### DIFF
--- a/src/extension/js/contentscript.ts
+++ b/src/extension/js/contentscript.ts
@@ -24,11 +24,14 @@ const FONT_COLOR_STYLE_ID = 'dyslexia-friendly-font-color-style';
  * Apply (or clear) the user's chosen text color.
  *
  * Background presets and the namespace CSS set `color` with `!important` on
- * `body *` and various content selectors, so a plain inline style on `body`
- * can't win for descendants. We inject a dedicated <style> element whose
- * selectors match those of the presets (same specificity) but appear later in
- * document order, so the user's explicit choice wins. The style is removed
- * entirely when disabled so no leftover state remains.
+ * `body`, `body *`, and various content containers (article/main/section/p and
+ * matched divs), so a plain inline style on `body` can't win for descendants.
+ * Among `!important` rules the winner is decided by specificity: the preset
+ * container rules reach up to (0,3,2) (two namespace classes + a class-matching
+ * attribute + two element names). We therefore repeat the namespace class four
+ * times so our selector is (0,4,1) for descendants — a higher class count that
+ * beats every preset rule regardless of its element/attribute parts. The style
+ * is removed entirely when disabled so no leftover state remains.
  */
 function applyFontColor(enabled: boolean, color: string): void {
   const existing = document.getElementById(FONT_COLOR_STYLE_ID);
@@ -38,7 +41,8 @@ function applyFontColor(enabled: boolean, color: string): void {
     }
     return;
   }
-  const css = `body.${CSS_NAMESPACE},body.${CSS_NAMESPACE} *{color:${color} !important;}`;
+  const ns = `.${CSS_NAMESPACE}`.repeat(4);
+  const css = `body${ns},body${ns} *{color:${color} !important;}`;
   if (existing) {
     existing.textContent = css;
   } else {

--- a/src/extension/js/contentscript.ts
+++ b/src/extension/js/contentscript.ts
@@ -18,6 +18,37 @@ interface RuntimeMessage {
 
 const ruler = $(`<div id="${RULER_ID}"></div>`);
 
+const FONT_COLOR_STYLE_ID = 'dyslexia-friendly-font-color-style';
+
+/**
+ * Apply (or clear) the user's chosen text color.
+ *
+ * Background presets and the namespace CSS set `color` with `!important` on
+ * `body *` and various content selectors, so a plain inline style on `body`
+ * can't win for descendants. We inject a dedicated <style> element whose
+ * selectors match those of the presets (same specificity) but appear later in
+ * document order, so the user's explicit choice wins. The style is removed
+ * entirely when disabled so no leftover state remains.
+ */
+function applyFontColor(enabled: boolean, color: string): void {
+  const existing = document.getElementById(FONT_COLOR_STYLE_ID);
+  if (!enabled) {
+    if (existing) {
+      existing.remove();
+    }
+    return;
+  }
+  const css = `body.${CSS_NAMESPACE},body.${CSS_NAMESPACE} *{color:${color} !important;}`;
+  if (existing) {
+    existing.textContent = css;
+  } else {
+    const style = document.createElement('style');
+    style.id = FONT_COLOR_STYLE_ID;
+    style.textContent = css;
+    document.head.appendChild(style);
+  }
+}
+
 $(document).ready(function () {
   const body = $('body');
   body.append(ruler);
@@ -58,6 +89,9 @@ $(document).ready(function () {
         body.addClass(BACKGROUND_CLASS_PREFIX + config.backgroundChoice);
       }
 
+      // text color: the user's explicit choice wins over background presets
+      applyFontColor(config.fontColorEnabled, config.fontColor);
+
       // ruler
       ruler.css('background-color', config.rulerColor);
       ruler.css('opacity', config.rulerOpacity);
@@ -75,6 +109,7 @@ $(document).ready(function () {
       removeClassStartsWith(body, FONT_CLASS_PREFIX);
       removeClassStartsWith(body, BACKGROUND_CLASS_PREFIX);
       body.css('background-color', '');
+      applyFontColor(false, config.fontColor);
       applyFontScale(root, false, config.fontSize);
       ruler.hide();
     }

--- a/src/extension/js/lib/__tests__/store.test.ts
+++ b/src/extension/js/lib/__tests__/store.test.ts
@@ -158,6 +158,22 @@ describe('store', () => {
     expect(result.customBackgroundColor).toBe('#ffcc00');
   });
 
+  test('default config includes font color options', () => {
+    expect(DEFAULT_CONFIG.fontColorEnabled).toBe(false);
+    expect(DEFAULT_CONFIG.fontColor).toBe('#000000');
+  });
+
+  test('updates font color', () => {
+    const storedConfig = { ...DEFAULT_CONFIG };
+    const newConfigValues = {
+      fontColorEnabled: true,
+      fontColor: '#cc0033',
+    };
+    const result = updateChangedConfigValues(storedConfig, newConfigValues);
+    expect(result.fontColorEnabled).toBe(true);
+    expect(result.fontColor).toBe('#cc0033');
+  });
+
   test('supports all background color options', () => {
     const supportedBackgrounds = ['none', 'classic', 'cream', 'softblue', 'paleyellow', 'custom'];
     

--- a/src/extension/js/lib/store.ts
+++ b/src/extension/js/lib/store.ts
@@ -13,6 +13,8 @@ export interface UserConfig {
   backgroundEnabled: boolean;
   backgroundChoice: string;
   customBackgroundColor: string;
+  fontColorEnabled: boolean;
+  fontColor: string;
 }
 
 export type ConfigKey = keyof UserConfig;
@@ -35,6 +37,8 @@ export const DEFAULT_CONFIG: UserConfig = {
   backgroundEnabled: false,
   backgroundChoice: 'none',
   customBackgroundColor: '#fdf6e3',
+  fontColorEnabled: false,
+  fontColor: '#000000',
 };
 
 export const updateChangedConfigValues = (

--- a/src/extension/js/popup.ts
+++ b/src/extension/js/popup.ts
@@ -106,6 +106,12 @@ function updateUiFromConfig(
     body.addClass(BACKGROUND_CLASS_PREFIX + config.backgroundChoice);
   }
 
+  // toggle font (text) color live preview in the popup
+  body.css('color', '');
+  if (config.fontColorEnabled) {
+    body.css('color', config.fontColor);
+  }
+
   // only show the custom color picker when the custom background is selected
   const customColorWrapper = $('#background-custom-color-wrapper');
   if (config.backgroundChoice === 'custom') {

--- a/src/extension/popup.html
+++ b/src/extension/popup.html
@@ -281,6 +281,31 @@
 
           <div class="popup-section" data-show-when="extensionEnabled">
             <div class="popup-section-header">
+              <h2>Font color</h2>
+              <div
+                class="form-check form-switch active-switch"
+                id="font-color-switch"
+              >
+                <input
+                  class="me-2 mt-[0.3rem] h-3.5 w-8 appearance-none rounded-[0.4375rem] bg-black/25 before:pointer-events-none before:absolute before:h-3.5 before:w-3.5 before:rounded-full before:bg-transparent before:content-[''] after:absolute after:z-[2] after:-mt-[0.1875rem] after:h-5 after:w-5 after:rounded-full after:border-none after:bg-white after:shadow-switch-2 after:transition-[background-color_0.2s,transform_0.2s] after:content-[''] checked:bg-primary checked:after:absolute checked:after:z-[2] checked:after:-mt-[3px] checked:after:ms-[1.0625rem] checked:after:h-5 checked:after:w-5 checked:after:rounded-full checked:after:border-none checked:after:bg-primary checked:after:shadow-switch-1 checked:after:transition-[background-color_0.2s,transform_0.2s] checked:after:content-[''] hover:cursor-pointer focus:outline-none focus:before:scale-100 focus:before:opacity-[0.12] focus:before:shadow-switch-3 focus:before:shadow-black/60 focus:before:transition-[box-shadow_0.2s,transform_0.2s] focus:after:absolute focus:after:z-[1] focus:after:block focus:after:h-5 focus:after:w-5 focus:after:rounded-full focus:after:content-[''] checked:focus:border-primary checked:focus:bg-primary checked:focus:before:ms-[1.0625rem] checked:focus:before:scale-100 checked:focus:before:shadow-switch-3 checked:focus:before:transition-[box-shadow_0.2s,transform_0.2s] dark:bg-white/25 dark:after:bg-surface-dark dark:checked:bg-primary dark:checked:after:bg-primary"
+                  type="checkbox"
+                  role="switch"
+                  name="fontColorEnabled"
+                  id="font-color-switch-checkbox"
+                />
+              </div>
+            </div>
+
+            <div class="popup-section-body" data-show-when="fontColorEnabled">
+              <div class="relative">
+                <label for="font-color" class="form-label">Color:</label>
+                <input type="color" name="fontColor" id="font-color" />
+              </div>
+            </div>
+          </div>
+
+          <div class="popup-section" data-show-when="extensionEnabled">
+            <div class="popup-section-header">
               <h2>Ruler</h2>
               <div
                 class="form-check form-switch active-switch"


### PR DESCRIPTION
## What

Adds a user-configurable text (font) color picker to the extension popup, alongside a switch to enable/disable it. Mirrors the existing custom background color and ruler color features.

## Why

Some dyslexic readers benefit from a specific text color (e.g. higher/lower contrast against the background). This gives users explicit control over text color.

## Notes

- New config fields `fontColorEnabled` (default `false`) and `fontColor` (default `#000000`).
- Background presets and the namespace CSS set `color` with `!important` on `body *`. To make the user's choice win, the content script injects a dedicated `<style>` element with matching specificity that appears later in document order. It's removed entirely when disabled, leaving no leftover state.
- Verified with Puppeteer against the built extension: with `fontColor:#cc0033` the computed `<p>` color is `rgb(204, 0, 51)`, and it still wins when the cream background preset (which sets text `#5c4317`) is also enabled. Disabling removes the style element and reverts to default.

<img width="800" src="https://github.com/javoire/pr-assets/raw/main/screenshots/1780182791-227664.png" />

[RAN-15](https://linear.app/randomcreations/issue/RAN-15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)