### PR TITLE
feat(extension): add more font options (RAN-16)

### DIFF
--- a/src/extension/css/contentscript.css
+++ b/src/extension/css/contentscript.css
@@ -64,6 +64,40 @@ body.dyslexia-friendly.dyslexia-friendly-font-comicsans h6 {
   line-height: 200% !important;
 }
 
+body.dyslexia-friendly.dyslexia-friendly-font-trebuchet *,
+body.dyslexia-friendly.dyslexia-friendly-font-trebuchet article,
+body.dyslexia-friendly.dyslexia-friendly-font-trebuchet main,
+body.dyslexia-friendly.dyslexia-friendly-font-trebuchet section,
+body.dyslexia-friendly.dyslexia-friendly-font-trebuchet div,
+body.dyslexia-friendly.dyslexia-friendly-font-trebuchet p,
+body.dyslexia-friendly.dyslexia-friendly-font-trebuchet span,
+body.dyslexia-friendly.dyslexia-friendly-font-trebuchet h1,
+body.dyslexia-friendly.dyslexia-friendly-font-trebuchet h2,
+body.dyslexia-friendly.dyslexia-friendly-font-trebuchet h3,
+body.dyslexia-friendly.dyslexia-friendly-font-trebuchet h4,
+body.dyslexia-friendly.dyslexia-friendly-font-trebuchet h5,
+body.dyslexia-friendly.dyslexia-friendly-font-trebuchet h6 {
+  font-family: 'Trebuchet MS' !important;
+  line-height: 200% !important;
+}
+
+body.dyslexia-friendly.dyslexia-friendly-font-couriernew *,
+body.dyslexia-friendly.dyslexia-friendly-font-couriernew article,
+body.dyslexia-friendly.dyslexia-friendly-font-couriernew main,
+body.dyslexia-friendly.dyslexia-friendly-font-couriernew section,
+body.dyslexia-friendly.dyslexia-friendly-font-couriernew div,
+body.dyslexia-friendly.dyslexia-friendly-font-couriernew p,
+body.dyslexia-friendly.dyslexia-friendly-font-couriernew span,
+body.dyslexia-friendly.dyslexia-friendly-font-couriernew h1,
+body.dyslexia-friendly.dyslexia-friendly-font-couriernew h2,
+body.dyslexia-friendly.dyslexia-friendly-font-couriernew h3,
+body.dyslexia-friendly.dyslexia-friendly-font-couriernew h4,
+body.dyslexia-friendly.dyslexia-friendly-font-couriernew h5,
+body.dyslexia-friendly.dyslexia-friendly-font-couriernew h6 {
+  font-family: 'Courier New', Courier, monospace !important;
+  line-height: 200% !important;
+}
+
 /* Background color options for improved readability
  *
  * Color choices based on accessibility research:

--- a/src/extension/css/popup.css
+++ b/src/extension/css/popup.css
@@ -25,8 +25,24 @@ body.dyslexia-friendly-font-comicsans {
   font-family: 'Comic Sans MS' !important;
 }
 
+body.dyslexia-friendly-font-trebuchet {
+  font-family: 'Trebuchet MS' !important;
+}
+
+body.dyslexia-friendly-font-couriernew {
+  font-family: 'Courier New', Courier, monospace !important;
+}
+
 label[for='font-comicsans-radio'] {
   font-family: 'Comic Sans MS' !important;
+}
+
+label[for='font-trebuchet-radio'] {
+  font-family: 'Trebuchet MS' !important;
+}
+
+label[for='font-couriernew-radio'] {
+  font-family: 'Courier New', Courier, monospace !important;
 }
 
 label[for='font-opendyslexic-radio'] {

--- a/src/extension/popup.html
+++ b/src/extension/popup.html
@@ -113,6 +113,38 @@
                 </label>
               </div>
 
+              <div class="mb-[0.125rem] block min-h-[1.5rem] ps-[1.5rem]">
+                <input
+                  class="relative float-left -ms-[1.5rem] me-1 mt-0.5 h-5 w-5 appearance-none rounded-full border-2 border-solid border-secondary-500 before:pointer-events-none before:absolute before:h-4 before:w-4 before:scale-0 before:rounded-full before:bg-transparent before:opacity-0 before:shadow-checkbox before:shadow-transparent before:content-[''] after:absolute after:z-[1] after:block after:h-4 after:w-4 after:rounded-full after:content-[''] checked:border-primary checked:before:opacity-[0.16] checked:after:absolute checked:after:left-1/2 checked:after:top-1/2 checked:after:h-[0.625rem] checked:after:w-[0.625rem] checked:after:rounded-full checked:after:border-primary checked:after:bg-primary checked:after:content-[''] checked:after:[transform:translate(-50%,-50%)] hover:cursor-pointer hover:before:opacity-[0.04] hover:before:shadow-black/60 focus:shadow-none focus:outline-none focus:ring-0 focus:before:scale-100 focus:before:opacity-[0.12] focus:before:shadow-black/60 focus:before:transition-[box-shadow_0.2s,transform_0.2s] checked:focus:border-primary checked:focus:before:scale-100 checked:focus:before:shadow-checkbox checked:focus:before:transition-[box-shadow_0.2s,transform_0.2s] rtl:float-right dark:border-neutral-400 dark:checked:border-primary"
+                  type="radio"
+                  name="fontChoice"
+                  id="font-trebuchet-radio"
+                  value="trebuchet"
+                />
+                <label
+                  class="mt-px inline-block ps-[0.15rem] hover:cursor-pointer"
+                  for="font-trebuchet-radio"
+                >
+                  Trebuchet MS
+                </label>
+              </div>
+
+              <div class="mb-[0.125rem] block min-h-[1.5rem] ps-[1.5rem]">
+                <input
+                  class="relative float-left -ms-[1.5rem] me-1 mt-0.5 h-5 w-5 appearance-none rounded-full border-2 border-solid border-secondary-500 before:pointer-events-none before:absolute before:h-4 before:w-4 before:scale-0 before:rounded-full before:bg-transparent before:opacity-0 before:shadow-checkbox before:shadow-transparent before:content-[''] after:absolute after:z-[1] after:block after:h-4 after:w-4 after:rounded-full after:content-[''] checked:border-primary checked:before:opacity-[0.16] checked:after:absolute checked:after:left-1/2 checked:after:top-1/2 checked:after:h-[0.625rem] checked:after:w-[0.625rem] checked:after:rounded-full checked:after:border-primary checked:after:bg-primary checked:after:content-[''] checked:after:[transform:translate(-50%,-50%)] hover:cursor-pointer hover:before:opacity-[0.04] hover:before:shadow-black/60 focus:shadow-none focus:outline-none focus:ring-0 focus:before:scale-100 focus:before:opacity-[0.12] focus:before:shadow-black/60 focus:before:transition-[box-shadow_0.2s,transform_0.2s] checked:focus:border-primary checked:focus:before:scale-100 checked:focus:before:shadow-checkbox checked:focus:before:transition-[box-shadow_0.2s,transform_0.2s] rtl:float-right dark:border-neutral-400 dark:checked:border-primary"
+                  type="radio"
+                  name="fontChoice"
+                  id="font-couriernew-radio"
+                  value="couriernew"
+                />
+                <label
+                  class="mt-px inline-block ps-[0.15rem] hover:cursor-pointer"
+                  for="font-couriernew-radio"
+                >
+                  Courier New
+                </label>
+              </div>
+
               <div class="mt-4">
                 <div class="popup-section-header">
                   <h3>Font Size</h3>


### PR DESCRIPTION
Adds two new font options to the font picker, following the existing class-based pattern (`dyslexia-friendly-font-{name}`).

## Fonts added
- **Trebuchet MS** (`trebuchet`) — system font, no bundled binary (like the existing Comic Sans option).
- **Courier New** (`couriernew`) — monospace system font, no bundled binary. Falls back to `Courier, monospace`.

Each adds a radio in the Font section of `popup.html`, a content-script CSS rule block in `contentscript.css`, and a popup preview rule in `popup.css`. No store/TS changes needed — `fontChoice` is mapped directly to the class via `FONT_CLASS_PREFIX + fontChoice`.

## Fonts skipped (from RAN-16 scope)
- **DejaVu Sans, DejaVu Sans Mono, Liberation Mono** — these are open-licensed and *could* be bundled, but I could not source verified binaries cleanly in this environment (`woff2_compress`/`fc-list` unavailable, fonts not present on the system). Per the licensing rule, I did not commit any unverified font binaries. These can be added in a follow-up once the binaries are sourced through the existing fonts pipeline.
- **Courier** — covered by Courier New (with `Courier, monospace` fallback in the CSS).

## Licensing
No font binaries bundled. Trebuchet MS and Courier New are referenced by system font name only, exactly like the pre-existing Comic Sans option.

## Verification
- `yarn lint`, `yarn build`, unit + integration tests (28 passed) all green.
- Visual check against the built extension via Puppeteer on a local `http` page: asserted `getComputedStyle(document.querySelector('p')).fontFamily` === `"Trebuchet MS"` with body class `dyslexia-friendly dyslexia-friendly-font-trebuchet`.

<img width="800" src="https://github.com/javoire/pr-assets/raw/main/screenshots/1780183079-e809d0.png" />

[RAN-16](https://linear.app/randomcreations/issue/RAN-16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)