### PR TITLE
fix(ci): stop weekly release from pushing to protected main (RAN-189)

### DIFF
--- a/.github/workflows/weekly-publish.yml
+++ b/.github/workflows/weekly-publish.yml
@@ -30,16 +30,10 @@ jobs:
         uses: cycjimmy/semantic-release-action@v4
         with:
           extra_plugins: |
-            @semantic-release/changelog
-            @semantic-release/git
             @semantic-release/exec
             conventional-changelog-conventionalcommits
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout new tag
-        if: steps.release.outputs.new_release_published == 'true'
-        run: git checkout "v${{ steps.release.outputs.new_release_version }}"
 
       - name: Install dependencies
         if: steps.release.outputs.new_release_published == 'true'

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -4,14 +4,8 @@ branches:
 plugins:
   - "@semantic-release/commit-analyzer"
   - "@semantic-release/release-notes-generator"
-  - "@semantic-release/changelog"
   - - "@semantic-release/exec"
     - prepareCmd: "jq --arg v '${nextRelease.version}' '.version = $v' src/extension/manifest.json > tmp.json && mv tmp.json src/extension/manifest.json"
-  - - "@semantic-release/git"
-    - assets:
-        - CHANGELOG.md
-        - src/extension/manifest.json
-      message: "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
   - "@semantic-release/github"
 
 preset: conventionalcommits


### PR DESCRIPTION
## What & why

The `Weekly Auto-Release` workflow has **never produced a release** — the last real release, `v2.7.0`, predates it. semantic-release runs `@semantic-release/git`, which commits `CHANGELOG.md` + `manifest.json` back to `main` and pushes; the `main` ruleset rejects the push (GH013), aborting the release. No tag / GitHub release is created, so the gated Build / Package / Publish-to-Chrome steps never run. Unreleased work (RAN-176, RAN-21, …) has been stuck, unshipped.

## Fix

The commit-back isn't needed for a correct release: semantic-release derives the previous version from **git tags**, and `@semantic-release/exec` already writes the bumped version into the working-tree `manifest.json`, which the build copies into the zip.

- **`.releaserc.yml`**: remove `@semantic-release/git` (the blocked push) and `@semantic-release/changelog` (dead weight without the git plugin). Keep `exec` + `github`.
- **`.github/workflows/weekly-publish.yml`**: remove the now-harmful `Checkout new tag` step (it would revert `manifest.json` to the stale version) and the removed plugins from `extra_plugins`. Build/package/publish run on the `exec`-bumped workspace.

No new secrets, no ruleset change, no automated commits to protected `main`. Trade-off: committed `manifest.json`/`CHANGELOG.md` stay static in the repo — version correctness comes from the git tag and the built zip is always correct.

## Verified

Dry-run against real `origin/main` computes next version **2.8.0** from commits since `v2.7.0`, with no branch push attempted. Running the `exec` bump + `yarn build`/`yarn package` produces a zip whose `manifest.json` reads `2.8.0`.

Closes RAN-189

🤖 Generated with [Claude Code](https://claude.com/claude-code)